### PR TITLE
LPS-113197 Return the staging group's groupId when remote staging is active

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
@@ -495,10 +495,14 @@ public class JournalContentDisplayContext {
 	public long getGroupId() {
 		long groupId = _themeDisplay.getScopeGroupId();
 
-		Group scopeGroup = _themeDisplay.getScopeGroup();
+		StagingGroupHelper stagingGroupHelper =
+			StagingGroupHelperUtil.getStagingGroupHelper();
 
-		if (scopeGroup.isStaged() &&
-			!scopeGroup.isInStagingPortlet(JournalPortletKeys.JOURNAL)) {
+		if (stagingGroupHelper.isLocalStagingGroup(groupId) &&
+			!stagingGroupHelper.isStagedPortlet(
+				groupId, JournalPortletKeys.JOURNAL)) {
+
+			Group scopeGroup = _themeDisplay.getScopeGroup();
 
 			groupId = scopeGroup.getLiveGroupId();
 		}


### PR DESCRIPTION
Additional commit to [LPS-113197](https://issues.liferay.com/browse/LPS-113197): fix the getGroupId() method to return the right value in remote staging scenario, when web contents are also staged.

cc: @jonathanmccann