### PR TITLE
[TS] LPS-114206 Add new line to the list of stops strings to correctly get references from URLs that are missing query strings

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
@@ -733,8 +733,9 @@ public class DLReferencesExportImportContentProcessor
 		StringPool.APOSTROPHE, StringPool.APOSTROPHE_ENCODED,
 		StringPool.CLOSE_BRACKET, StringPool.CLOSE_CURLY_BRACE,
 		StringPool.CLOSE_PARENTHESIS, StringPool.GREATER_THAN,
-		StringPool.LESS_THAN, StringPool.PIPE, StringPool.QUESTION,
-		StringPool.QUOTE, StringPool.QUOTE_ENCODED, StringPool.SPACE
+		StringPool.LESS_THAN, StringPool.NEW_LINE, StringPool.PIPE,
+		StringPool.QUESTION, StringPool.QUOTE, StringPool.QUOTE_ENCODED,
+		StringPool.SPACE
 	};
 
 	private static final int _OFFSET_HREF_ATTRIBUTE = 6;


### PR DESCRIPTION
Resent from https://github.com/liferay-echo/liferay-portal/pull/749