### PR TITLE
[TS] LPS-116620 Split up changesetEntryIds when using SQL Server

### DIFF
--- a/modules/apps/changeset/changeset-service/src/main/java/com/liferay/changeset/service/impl/ChangesetEntryLocalServiceImpl.java
+++ b/modules/apps/changeset/changeset-service/src/main/java/com/liferay/changeset/service/impl/ChangesetEntryLocalServiceImpl.java
@@ -19,13 +19,19 @@ import com.liferay.changeset.model.ChangesetCollection;
 import com.liferay.changeset.model.ChangesetEntry;
 import com.liferay.changeset.service.base.ChangesetEntryLocalServiceBaseImpl;
 import com.liferay.portal.aop.AopService;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 
+import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
@@ -97,21 +103,29 @@ public class ChangesetEntryLocalServiceImpl
 			return;
 		}
 
-		ActionableDynamicQuery actionableDynamicQuery =
-			getActionableDynamicQuery();
+		DB db = DBManagerUtil.getDB();
 
-		actionableDynamicQuery.setAddCriteriaMethod(
-			dynamicQuery -> dynamicQuery.add(
-				RestrictionsFactoryUtil.in(
-					"changesetEntryId", changesetEntryIds)));
+		if (db.getDBType() != DBType.SQLSERVER) {
+			_deleteChangesetEntries(changesetEntryIds);
 
-		actionableDynamicQuery.setPerformActionMethod(
-			(ActionableDynamicQuery.PerformActionMethod<ChangesetEntry>)
-				changesetEntry ->
-					changesetEntryLocalService.deleteChangesetEntry(
-						changesetEntry));
+			return;
+		}
 
-		actionableDynamicQuery.performActions();
+		List<Long> changesetEntryIdsChunk = new LinkedList<>();
+
+		for (Long changesetEntryId : changesetEntryIds) {
+			if (changesetEntryIdsChunk.size() >= 2000) {
+				_deleteChangesetEntries(changesetEntryIdsChunk);
+
+				changesetEntryIdsChunk = new LinkedList<>();
+			}
+
+			changesetEntryIdsChunk.add(changesetEntryId);
+		}
+
+		if (!ListUtil.isEmpty(changesetEntryIdsChunk)) {
+			_deleteChangesetEntries(changesetEntryIdsChunk);
+		}
 	}
 
 	@Override
@@ -208,6 +222,27 @@ public class ChangesetEntryLocalServiceImpl
 
 		return changesetEntryPersistence.findByC_C_C(
 			changesetCollectionId, classNameId, classPK);
+	}
+
+	private void _deleteChangesetEntries(
+			Collection<Long> changesetEntryIdsChunk)
+		throws PortalException {
+
+		ActionableDynamicQuery actionableDynamicQuery =
+			getActionableDynamicQuery();
+
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> dynamicQuery.add(
+				RestrictionsFactoryUtil.in(
+					"changesetEntryId", changesetEntryIdsChunk)));
+
+		actionableDynamicQuery.setPerformActionMethod(
+			(ActionableDynamicQuery.PerformActionMethod<ChangesetEntry>)
+				changesetEntry ->
+					changesetEntryLocalService.deleteChangesetEntry(
+						changesetEntry));
+
+		actionableDynamicQuery.performActions();
 	}
 
 }

--- a/modules/apps/changeset/changeset-service/src/main/java/com/liferay/changeset/service/impl/ChangesetEntryLocalServiceImpl.java
+++ b/modules/apps/changeset/changeset-service/src/main/java/com/liferay/changeset/service/impl/ChangesetEntryLocalServiceImpl.java
@@ -111,20 +111,22 @@ public class ChangesetEntryLocalServiceImpl
 			return;
 		}
 
-		List<Long> changesetEntryIdsChunk = new LinkedList<>();
+		List<Long> changesetEntryIdsBatch = new LinkedList<>();
 
 		for (Long changesetEntryId : changesetEntryIds) {
-			if (changesetEntryIdsChunk.size() >= 2000) {
-				_deleteChangesetEntries(changesetEntryIdsChunk);
+			if (changesetEntryIdsBatch.size() >=
+					_CHANGESET_ENTRY_DELETE_BATCH_SIZE) {
 
-				changesetEntryIdsChunk = new LinkedList<>();
+				_deleteChangesetEntries(changesetEntryIdsBatch);
+
+				changesetEntryIdsBatch = new LinkedList<>();
 			}
 
-			changesetEntryIdsChunk.add(changesetEntryId);
+			changesetEntryIdsBatch.add(changesetEntryId);
 		}
 
-		if (!ListUtil.isEmpty(changesetEntryIdsChunk)) {
-			_deleteChangesetEntries(changesetEntryIdsChunk);
+		if (!ListUtil.isEmpty(changesetEntryIdsBatch)) {
+			_deleteChangesetEntries(changesetEntryIdsBatch);
 		}
 	}
 
@@ -224,8 +226,7 @@ public class ChangesetEntryLocalServiceImpl
 			changesetCollectionId, classNameId, classPK);
 	}
 
-	private void _deleteChangesetEntries(
-			Collection<Long> changesetEntryIdsChunk)
+	private void _deleteChangesetEntries(Collection<Long> changesetEntryIds)
 		throws PortalException {
 
 		ActionableDynamicQuery actionableDynamicQuery =
@@ -234,7 +235,7 @@ public class ChangesetEntryLocalServiceImpl
 		actionableDynamicQuery.setAddCriteriaMethod(
 			dynamicQuery -> dynamicQuery.add(
 				RestrictionsFactoryUtil.in(
-					"changesetEntryId", changesetEntryIdsChunk)));
+					"changesetEntryId", changesetEntryIds)));
 
 		actionableDynamicQuery.setPerformActionMethod(
 			(ActionableDynamicQuery.PerformActionMethod<ChangesetEntry>)
@@ -244,5 +245,7 @@ public class ChangesetEntryLocalServiceImpl
 
 		actionableDynamicQuery.performActions();
 	}
+
+	private static final int _CHANGESET_ENTRY_DELETE_BATCH_SIZE = 2000;
 
 }


### PR DESCRIPTION
Hi @brianchandotcom , 

According to https://github.com/brianchandotcom/liferay-portal/pull/91063#issuecomment-655588487 , we checked the possibility of using `setInterval()` on ActionableDynamicQuery, but unfortunately, it doesn't help in this case. Interval property only splits the result set, but not the query itself. The number of parameters in the query would stay the same, independently of the interval variable (it does not affect the number of parameters in the `IN (..)` condition). That's why we decided to manually chunk the list of Ids.

Original message from @balazssk:

> Hi @vendeltoreki ,
> 
> This proposed fix limits ChangesetEntry deletions to 2000 at a time if the used DB is SQL Server.
> The issue comes from an SQL Server limitation. Queries can only have 2100 parameters. During my tests, I could only add 2098 parameters for a dynamicQuery's IN criteria (maybe the table name and the * are also counted). I've chosen 2000 as a limit without any specific reason.
> 
> Can you please review?
> https://issues.liferay.com/browse/LPS-116620
> 
> Thanks,
> Balázs