### PR TITLE
LPS-120487

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -128,6 +128,7 @@ import com.liferay.sites.kernel.util.SitesUtil;
 
 import java.io.IOException;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -1681,7 +1682,10 @@ public class LayoutStagedModelDataHandler
 			ManifestSummary manifestSummary =
 				portletDataContext.getManifestSummary();
 
-			if (layout.isTypeAssetDisplay()) {
+			if (!_isPortletDefinedInManifest(
+					portletDataContext.getCompanyId(), portletId,
+					manifestSummary)) {
+
 				manifestSummary = null;
 			}
 
@@ -2398,6 +2402,18 @@ public class LayoutStagedModelDataHandler
 		}
 
 		return layout.getLayoutPrototypeUuid();
+	}
+
+	private boolean _isPortletDefinedInManifest(
+			long companyId, String portletId, ManifestSummary manifestSummary)
+		throws Exception {
+
+		Collection<String> manifestSummaryKeys =
+			manifestSummary.getManifestSummaryKeys();
+
+		return manifestSummaryKeys.contains(
+			_exportImportHelper.getExportableRootPortletId(
+				companyId, portletId));
 	}
 
 	private Layout _updateCollectionLayoutTypeSettings(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-120487

From @binhtran92:
> The old logic `layout.isTypeAssetDisplay()` was introduced by the ticket [LPS-106070](https://issues.liferay.com/browse/LPS-106070) to fixing the same issue as my ticket but in a different page template.
>
> I think it is not about the layout type, the root cause is that the portlet cannot find it's configuration on the `ManifestSummary` then it losing configuration
[ExportImportHelperImpl.java#L1218-L1232](https://github.com/hongvo2308/liferay-portal/blob/LPS-120487/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/ExportImportHelperImpl.java#L1218-L1232)
>
> this PR also cover for ticket `LPS-106070`