### PR TITLE
[TS] LPS-121342

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
@@ -1824,6 +1824,25 @@ public class StagingImpl implements Staging {
 	}
 
 	@Override
+	public Layout getRemoteLayout(long userId, long stagingGroupId, long plid)
+		throws PortalException {
+
+		Group stagingGroup = _groupLocalService.fetchGroup(stagingGroupId);
+		User user = _userLocalService.fetchUser(userId);
+
+		HttpPrincipal httpPrincipal = new HttpPrincipal(
+			_stagingURLHelper.buildRemoteURL(
+				stagingGroup.getTypeSettingsProperties()),
+			user.getLogin(), user.getPassword(), user.isPasswordEncrypted());
+
+		Layout layout = _layoutLocalService.fetchLayout(plid);
+
+		return LayoutServiceHttp.getLayoutByUuidAndGroupId(
+			httpPrincipal, layout.getUuid(),
+			stagingGroup.getRemoteLiveGroupId(), layout.isPrivateLayout());
+	}
+
+	@Override
 	public long getRemoteLayoutPlid(long userId, long stagingGroupId, long plid)
 		throws PortalException {
 

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
@@ -2049,6 +2049,25 @@ public class StagingImpl implements Staging {
 	}
 
 	@Override
+	public boolean hasRemoteLayout(long userId, long stagingGroupId, long plid)
+		throws PortalException {
+
+		Group stagingGroup = _groupLocalService.fetchGroup(stagingGroupId);
+		User user = _userLocalService.fetchUser(userId);
+
+		HttpPrincipal httpPrincipal = new HttpPrincipal(
+			_stagingURLHelper.buildRemoteURL(
+				stagingGroup.getTypeSettingsProperties()),
+			user.getLogin(), user.getPassword(), user.isPasswordEncrypted());
+
+		Layout layout = _layoutLocalService.fetchLayout(plid);
+
+		return LayoutServiceHttp.hasLayout(
+			httpPrincipal, layout.getUuid(),
+			stagingGroup.getRemoteLiveGroupId(), layout.isPrivateLayout());
+	}
+
+	@Override
 	public boolean hasWorkflowTask(long userId, LayoutRevision layoutRevision)
 		throws PortalException {
 

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
@@ -3226,7 +3226,9 @@ public class StagingImpl implements Staging {
 		String cmd = MapUtil.getString(parameterMap, Constants.CMD);
 
 		if (!cmd.equals(Constants.PUBLISH_TO_LIVE) &&
-			!cmd.equals("schedule_publish_to_live")) {
+			!cmd.equals(Constants.PUBLISH_TO_REMOTE) &&
+			!cmd.equals("schedule_publish_to_live") &&
+			!cmd.equals("schedule_publish_to_remote")) {
 
 			return;
 		}

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/init.jsp
@@ -138,7 +138,10 @@ private String _getStatusMessage(LayoutRevision layoutRevision, Group group, Lay
 		statusMessage = "ready-for-publication";
 	}
 
-	if (layoutRevision.getLayoutRevisionId() == _getLastImportLayoutRevisionId(group, layout, user)) {
+	if (layoutRevision.isApproved() &&
+		(layoutRevision.getLayoutRevisionId() ==
+			_getLastImportLayoutRevisionId(group, layout, user))) {
+
 		statusMessage = "in-live";
 	}
 

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/init.jsp
@@ -112,7 +112,9 @@ private long _getLastImportLayoutRevisionId(Group group, Layout layout, User use
 	try {
 		Layout liveLayout = null;
 
-		if (group.isStagedRemotely()) {
+		if (group.isStagedRemotely() &&
+			StagingUtil.hasRemoteLayout(user.getUserId(), group.getGroupId(), layout.getPlid())) {
+
 			liveLayout = StagingUtil.getRemoteLayout(user.getUserId(), group.getGroupId(), layout.getPlid());
 		}
 		else if (group.isStagingGroup()) {

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/init.jsp
@@ -131,17 +131,14 @@ private long _getLastImportLayoutRevisionId(Group group, Layout layout, User use
 	return lastImportLayoutRevisionId;
 }
 
-private String _getStatusMessage(LayoutRevision layoutRevision, Group group, Layout layout, User user) {
+private String _getStatusMessage(LayoutRevision layoutRevision, long liveLayoutRevisionId) {
 	String statusMessage = null;
 
 	if (layoutRevision.isHead()) {
 		statusMessage = "ready-for-publication";
 	}
 
-	if (layoutRevision.isApproved() &&
-		(layoutRevision.getLayoutRevisionId() ==
-			_getLastImportLayoutRevisionId(group, layout, user))) {
-
+	if (layoutRevision.getLayoutRevisionId() == liveLayoutRevisionId) {
 		statusMessage = "in-live";
 	}
 

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revision_status.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revision_status.jsp
@@ -22,6 +22,12 @@ LayoutRevision layoutRevision = (LayoutRevision)request.getAttribute(WebKeys.LAY
 if ((layoutRevision == null) && (layout != null)) {
 	layoutRevision = LayoutStagingUtil.getLayoutRevision(layout);
 }
+
+Long liveLayoutRevisionId = null;
+
+if (layoutRevision.isApproved()) {
+	liveLayoutRevisionId = _getLastImportLayoutRevisionId(group, layout, themeDisplay.getUser());
+}
 %>
 
 <span class="staging-bar-workflow-text text-center">
@@ -35,7 +41,7 @@ if ((layoutRevision == null) && (layout != null)) {
 
 			<aui:model-context bean="<%= layoutRevision %>" model="<%= LayoutRevision.class %>" />
 
-			<aui:workflow-status markupView="lexicon" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= layoutRevision.getStatus() %>" statusMessage="<%= _getStatusMessage(layoutRevision, group, layout, themeDisplay.getUser()) %>" />
+			<aui:workflow-status markupView="lexicon" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= layoutRevision.getStatus() %>" statusMessage="<%= _getStatusMessage(layoutRevision, GetterUtil.getLong(liveLayoutRevisionId)) %>" />
 		</div>
 	</div>
 </span>

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revision_status.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revision_status.jsp
@@ -35,7 +35,7 @@ if ((layoutRevision == null) && (layout != null)) {
 
 			<aui:model-context bean="<%= layoutRevision %>" model="<%= LayoutRevision.class %>" />
 
-			<aui:workflow-status markupView="lexicon" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= layoutRevision.getStatus() %>" statusMessage="<%= _getStatusMessage(layoutRevision, group, layout) %>" />
+			<aui:workflow-status markupView="lexicon" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= layoutRevision.getStatus() %>" statusMessage="<%= _getStatusMessage(layoutRevision, group, layout, themeDisplay.getUser()) %>" />
 		</div>
 	</div>
 </span>

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revisions.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revisions.jsp
@@ -32,6 +32,8 @@ else {
 	currentLayoutRevisionId = recentLayoutRevision.getLayoutRevisionId();
 }
 
+Long liveLayoutRevisionId = null;
+
 List<LayoutRevision> rootLayoutRevisions = LayoutRevisionLocalServiceUtil.getChildLayoutRevisions(layoutSetBranchId, LayoutRevisionConstants.DEFAULT_PARENT_LAYOUT_REVISION_ID, plid, QueryUtil.ALL_POS, QueryUtil.ALL_POS, new LayoutRevisionCreateDateComparator(true));
 %>
 
@@ -98,7 +100,13 @@ List<LayoutRevision> rootLayoutRevisions = LayoutRevisionLocalServiceUtil.getChi
 							>
 								<aui:model-context bean="<%= curLayoutRevision %>" model="<%= LayoutRevision.class %>" />
 
-								<aui:workflow-status showIcon="<%= false %>" showLabel="<%= false %>" status="<%= curLayoutRevision.getStatus() %>" statusMessage="<%= _getStatusMessage(curLayoutRevision, group, layout, themeDisplay.getUser()) %>" />
+								<%
+								if ((liveLayoutRevisionId == null) && curLayoutRevision.isApproved()) {
+									liveLayoutRevisionId = _getLastImportLayoutRevisionId(group, layout, themeDisplay.getUser());
+								}
+								%>
+
+								<aui:workflow-status showIcon="<%= false %>" showLabel="<%= false %>" status="<%= curLayoutRevision.getStatus() %>" statusMessage="<%= _getStatusMessage(curLayoutRevision, GetterUtil.getLong(liveLayoutRevisionId)) %>" />
 							</liferay-ui:search-container-column-text>
 
 							<liferay-ui:search-container-column-text

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revisions.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revisions.jsp
@@ -98,7 +98,7 @@ List<LayoutRevision> rootLayoutRevisions = LayoutRevisionLocalServiceUtil.getChi
 							>
 								<aui:model-context bean="<%= curLayoutRevision %>" model="<%= LayoutRevision.class %>" />
 
-								<aui:workflow-status showIcon="<%= false %>" showLabel="<%= false %>" status="<%= curLayoutRevision.getStatus() %>" statusMessage="<%= _getStatusMessage(curLayoutRevision, group, layout) %>" />
+								<aui:workflow-status showIcon="<%= false %>" showLabel="<%= false %>" status="<%= curLayoutRevision.getStatus() %>" statusMessage="<%= _getStatusMessage(curLayoutRevision, group, layout, themeDisplay.getUser()) %>" />
 							</liferay-ui:search-container-column-text>
 
 							<liferay-ui:search-container-column-text

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 9.6.1
+Bundle-Version: 9.7.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.test.*,\

--- a/portal-kernel/src/com/liferay/exportimport/kernel/staging/Staging.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/staging/Staging.java
@@ -119,6 +119,9 @@ public interface Staging {
 
 	public long getRecentLayoutSetBranchId(User user, long layoutSetId);
 
+	public Layout getRemoteLayout(long userId, long stagingGroupId, long plid)
+		throws PortalException;
+
 	public long getRemoteLayoutPlid(long userId, long stagingGroupId, long plid)
 		throws PortalException;
 

--- a/portal-kernel/src/com/liferay/exportimport/kernel/staging/Staging.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/staging/Staging.java
@@ -144,6 +144,9 @@ public interface Staging {
 			long userId, LayoutRevision layoutRevision)
 		throws PortalException;
 
+	public boolean hasRemoteLayout(long userId, long stagingGroupId, long plid)
+		throws PortalException;
+
 	public boolean hasWorkflowTask(long userId, LayoutRevision layoutRevision)
 		throws PortalException;
 

--- a/portal-kernel/src/com/liferay/exportimport/kernel/staging/StagingUtil.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/staging/StagingUtil.java
@@ -240,6 +240,13 @@ public class StagingUtil {
 		return _staging.getWorkflowTask(userId, layoutRevision);
 	}
 
+	public static boolean hasRemoteLayout(
+			long userId, long stagingGroupId, long plid)
+		throws PortalException {
+
+		return _staging.hasRemoteLayout(userId, stagingGroupId, plid);
+	}
+
 	public static boolean hasWorkflowTask(
 			long userId, LayoutRevision layoutRevision)
 		throws PortalException {

--- a/portal-kernel/src/com/liferay/exportimport/kernel/staging/StagingUtil.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/staging/StagingUtil.java
@@ -186,6 +186,13 @@ public class StagingUtil {
 		return _staging.getRecentLayoutSetBranchId(user, layoutSetId);
 	}
 
+	public static Layout getRemoteLayout(
+			long userId, long stagingGroupId, long plid)
+		throws PortalException {
+
+		return _staging.getRemoteLayout(userId, stagingGroupId, plid);
+	}
+
 	public static long getRemoteLayoutPlid(
 			long userId, long stagingGroupId, long plid)
 		throws PortalException {

--- a/portal-kernel/src/com/liferay/exportimport/kernel/staging/packageinfo
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/staging/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0

--- a/portal-kernel/src/com/liferay/portal/kernel/service/http/TunnelUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/http/TunnelUtil.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.MethodHandler;
 import com.liferay.portal.kernel.util.ObjectValuePair;
+import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.ProtectedClassLoaderObjectInputStream;
@@ -78,7 +79,7 @@ public class TunnelUtil {
 				new ProtectedClassLoaderObjectInputStream(
 					httpURLConnection.getInputStream(),
 					AggregateClassLoader.getAggregateClassLoader(
-						TunnelUtil.class.getClassLoader(),
+						PortalClassLoaderUtil.getClassLoader(),
 						thread.getContextClassLoader()))) {
 
 			returnObject = objectInputStream.readObject();


### PR DESCRIPTION
Hi @vendeltoreki 

We have a customer that is using Remote Staging that is complaining about the lack of information about which revision page is published in Live server

That problem was adressed for Local Staging in https://issues.liferay.com/browse/LPS-119922

I have extended that solution to also address the remote staging case:

- ([1st commit](https://github.com/vendeltoreki/liferay-portal/pull/124/commits/75be6edc27541106099419bc6af73349327651b7)) I have modified `_getLastImportLayoutRevisionId` method in init.jsp to get the layout page from remote server calling a new `StagingImpl.getRemoteLayout` method that is similar to existing `StagingImpl.getRemoteLayoutPlid`
- ([2nd commit](https://github.com/vendeltoreki/liferay-portal/pull/124/commits/42372ff7770241848cf14c9373609d6d9c905f34)) I have modified `StagingImpl.updateLastImportSettings` to update the last-import-layout-revision-id information when we are importing in Remote Staging
- ([3rd commit](https://github.com/vendeltoreki/liferay-portal/pull/124/commits/1258a4b4f3b61f3b7bb1e364e278bb649075291f)) I have done a small change in TunnelUtil.java to avoid a ClassNotFoundException
- (4th to 6th commits) I have done some improvements to minimize the numbers of calls to the remote server and to avoid some exceptions in case the Layout doesn't exist in Live.

Let me know if you need more information.

Regads,
Jorge