### PR TITLE
LPS-122092 Move help icons from the popup to the Staging bar

### DIFF
--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_branch_details.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_branch_details.jsp
@@ -26,7 +26,13 @@ List<LayoutRevision> layoutRevisions = LayoutRevisionLocalServiceUtil.getChildLa
 %>
 
 <div class="control-menu-label staging-variation-label">
-	<liferay-ui:message key="page-variations" />
+	<liferay-util:buffer
+		var="pageVariationsHelpIcon"
+	>
+		<liferay-ui:icon-help message="page-variations-help" />
+	</liferay-util:buffer>
+
+	<liferay-ui:message arguments="<%= pageVariationsHelpIcon %>" key="page-variations-x" />
 </div>
 
 <div class="dropdown">

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revision_details.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revision_details.jsp
@@ -244,18 +244,6 @@ else {
 	});
 </aui:script>
 
-<liferay-util:buffer
-	var="pageVariationsHelpIcon"
->
-	<liferay-ui:icon-help message="page-variations-help" />
-</liferay-util:buffer>
-
-<liferay-util:buffer
-	var="sitePagesVariationsHelpIcon"
->
-	<liferay-ui:icon-help message="pages-variations-help" />
-</liferay-util:buffer>
-
 <aui:script>
 	function <portlet:namespace />openPageVariationsDialog() {
 		Liferay.Util.openWindow({
@@ -268,8 +256,7 @@ else {
 				destroyOnHide: true,
 			},
 			id: 'pagesVariationsDialog',
-			title:
-				'<liferay-ui:message arguments="<%= pageVariationsHelpIcon %>" key="page-variations-x" />',
+			title: '<liferay-ui:message key="page-variations" />',
 
 			<liferay-portlet:renderURL var="layoutBranchesURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
 				<portlet:param name="mvcRenderCommandName" value="viewLayoutBranches" />
@@ -291,8 +278,7 @@ else {
 				destroyOnHide: true,
 			},
 			id: 'sitePagesVariationDialog',
-			title:
-				'<liferay-ui:message arguments="<%= sitePagesVariationsHelpIcon %>" key="site-pages-variation-x" />',
+			title: '<liferay-ui:message key="site-pages-variation" />',
 
 			<liferay-portlet:renderURL var="layoutSetBranchesURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
 				<portlet:param name="mvcRenderCommandName" value="viewLayoutSetBranches" />

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_set_branch_details.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_set_branch_details.jsp
@@ -24,7 +24,13 @@ List<LayoutSetBranch> layoutSetBranches = (List<LayoutSetBranch>)request.getAttr
 
 <c:if test="<%= (layoutSetBranches != null) && !layoutSetBranches.isEmpty() %>">
 	<div class="control-menu-label staging-variation-label">
-		<liferay-ui:message key="site-pages-variation" />
+		<liferay-util:buffer
+			var="sitePagesVariationsHelpIcon"
+		>
+			<liferay-ui:icon-help message="pages-variations-help" />
+		</liferay-util:buffer>
+
+		<liferay-ui:message arguments="<%= sitePagesVariationsHelpIcon %>" key="site-pages-variation-x" />
 	</div>
 
 	<div class="dropdown">


### PR DESCRIPTION
Hi Vendel,

Since [LPS-121439](https://issues.liferay.com/browse/LPS-121439) the popup titles are escaped which ruined the display of the tooltips.

As I couldn't find any other places where HTML were used in a popup title, with Zsiga we decided to move the help icons from the popup to the staging bar.

Best,
Tamas