### PR TITLE
[TS] LPS-122694 Don't add a new RecentLayoutRevision entry during staging operations

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
@@ -3922,7 +3922,9 @@ public class StagingImpl implements Staging {
 			long layoutRevisionId)
 		throws PortalException {
 
-		if (layoutRevisionId <= 0) {
+		if ((layoutRevisionId <= 0) ||
+			ExportImportThreadLocal.isLayoutStagingInProcess()) {
+
 			return;
 		}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-122694

Publishing a Page to Live hides the Draft versions that exist after the version marked as "Ready for Publication".

This is caused because the publish operation changes the version that is consider the "Current Version" to the last "Ready for publication" version, hidding the Draft versions that are more recent.

This problem is reproduced after [LPS-78292](https://issues.liferay.com/browse/LPS-78292) changes because that LPS adds this code block in the StagingImpl.getRecentLayoutRevisionId method:
* https://github.com/liferay/liferay-portal/blob/9f782bf5a3a61a1374b180a1a6050aff35917261/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java#L3582-L3594
Always returning the head version during Staging operations.

Having the head version during Staging operations, causes this other code to add a new RecentLayoutRevision record to database:
* https://github.com/liferay/liferay-portal/blob/9f782bf5a3a61a1374b180a1a6050aff35917261/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java#L3941-L3961

For more information, see reproduction steps in https://issues.liferay.com/browse/LPS-122694

