### PR TITLE
LPS-123058 Ensure the companyId is set when updating using the imported model itself

### DIFF
--- a/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/internal/exportimport/data/handler/AssetDisplayPageStagedModelDataHandler.java
+++ b/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/internal/exportimport/data/handler/AssetDisplayPageStagedModelDataHandler.java
@@ -108,6 +108,8 @@ public class AssetDisplayPageStagedModelDataHandler
 
 		importedAssetDisplayPageEntry.setGroupId(
 			portletDataContext.getScopeGroupId());
+		importedAssetDisplayPageEntry.setCompanyId(
+			portletDataContext.getCompanyId());
 		importedAssetDisplayPageEntry.setLayoutPageTemplateEntryId(
 			layoutPageTemplateEntryId);
 		importedAssetDisplayPageEntry.setPlid(plid);

--- a/modules/apps/data-engine/data-engine-service/src/main/java/com/liferay/data/engine/internal/exportimport/data/handler/DEDataDefinitionFieldLinkStagedModelDataHandler.java
+++ b/modules/apps/data-engine/data-engine-service/src/main/java/com/liferay/data/engine/internal/exportimport/data/handler/DEDataDefinitionFieldLinkStagedModelDataHandler.java
@@ -138,6 +138,8 @@ public class DEDataDefinitionFieldLinkStagedModelDataHandler
 
 		importedDEDataDefinitionFieldLink.setGroupId(
 			portletDataContext.getScopeGroupId());
+		importedDEDataDefinitionFieldLink.setCompanyId(
+			portletDataContext.getCompanyId());
 		importedDEDataDefinitionFieldLink.setClassNameId(
 			_portal.getClassNameId(
 				deDataDefinitionFieldLinkElement.attributeValue(

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutPageTemplateStructureRelStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutPageTemplateStructureRelStagedModelDataHandler.java
@@ -116,6 +116,8 @@ public class LayoutPageTemplateStructureRelStagedModelDataHandler
 
 		importedLayoutPageTemplateStructureRel.setGroupId(
 			portletDataContext.getScopeGroupId());
+		importedLayoutPageTemplateStructureRel.setCompanyId(
+			portletDataContext.getCompanyId());
 		importedLayoutPageTemplateStructureRel.setLayoutPageTemplateStructureId(
 			layoutPageTemplateStructureId);
 		importedLayoutPageTemplateStructureRel.setSegmentsExperienceId(

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutPageTemplateStructureStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutPageTemplateStructureStagedModelDataHandler.java
@@ -78,6 +78,8 @@ public class LayoutPageTemplateStructureStagedModelDataHandler
 
 		importedLayoutPageTemplateStructure.setGroupId(
 			portletDataContext.getScopeGroupId());
+		importedLayoutPageTemplateStructure.setCompanyId(
+			portletDataContext.getCompanyId());
 
 		Element element = portletDataContext.getImportDataElement(
 			importedLayoutPageTemplateStructure);

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/LayoutClassedModelUsageStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/LayoutClassedModelUsageStagedModelDataHandler.java
@@ -173,6 +173,8 @@ public class LayoutClassedModelUsageStagedModelDataHandler
 
 		importedLayoutClassedModelUsage.setGroupId(
 			portletDataContext.getScopeGroupId());
+		importedLayoutClassedModelUsage.setCompanyId(
+			portletDataContext.getCompanyId());
 
 		Map<Long, Long> plids =
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/exportimport/data/handler/SegmentsEntryStagedModelDataHandler.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/exportimport/data/handler/SegmentsEntryStagedModelDataHandler.java
@@ -115,6 +115,7 @@ public class SegmentsEntryStagedModelDataHandler
 			(SegmentsEntry)segmentsEntry.clone();
 
 		importedSegmentsEntry.setGroupId(portletDataContext.getScopeGroupId());
+		importedSegmentsEntry.setCompanyId(portletDataContext.getCompanyId());
 
 		String criteria =
 			_segmentsEntryExportImportContentProcessor.

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/exportimport/data/handler/SegmentsExperienceStagedModelDataHandler.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/exportimport/data/handler/SegmentsExperienceStagedModelDataHandler.java
@@ -154,6 +154,8 @@ public class SegmentsExperienceStagedModelDataHandler
 
 		importedSegmentsExperience.setGroupId(
 			portletDataContext.getScopeGroupId());
+		importedSegmentsExperience.setCompanyId(
+			portletDataContext.getCompanyId());
 		importedSegmentsExperience.setSegmentsEntryId(segmentsEntryId);
 		importedSegmentsExperience.setClassPK(referenceClassPK);
 


### PR DESCRIPTION
In some cases, the imported model itself is used to update the entry on the live side:

https://github.com/liferay/liferay-portal/blob/master/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/exportimport/staged/model/repository/SegmentsEntryStagedModelRepository.java#L137
https://github.com/liferay/liferay-portal/blob/master/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/internal/exportimport/staged/model/repository/AssetDisplayPageStagedModelRepository.java#L151

In cases like these the company ID of the live site will be overwritten by the one from the remote site.

I believe I found all of the cases where this happens but please let me know if I missed one.

Thank you.