### PR TITLE
LPS-123482 Check the virtual layout case in order to see whether the staged site has private pages or not

### DIFF
--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/display/context/SiteAdministrationPanelCategoryDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/display/context/SiteAdministrationPanelCategoryDisplayContext.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.impl.VirtualLayout;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
@@ -176,9 +177,21 @@ public class SiteAdministrationPanelCategoryDisplayContext {
 		if (group.isStagedRemotely()) {
 			Layout layout = _themeDisplay.getLayout();
 
+			boolean privateLayout = layout.isPrivateLayout();
+
+			if (layout instanceof VirtualLayout) {
+				VirtualLayout virtualLayout = (VirtualLayout)layout;
+
+				Group targetGroup = virtualLayout.getGroup();
+
+				if (!targetGroup.hasPrivateLayouts()) {
+					privateLayout = false;
+				}
+			}
+
 			try {
 				_liveGroupURL = StagingUtil.getRemoteSiteURL(
-					group, layout.isPrivateLayout());
+					group, privateLayout);
 			}
 			catch (PortalException portalException) {
 				if (_log.isDebugEnabled()) {


### PR DESCRIPTION
Hi @vendeltoreki,

This solution tries to cover the case where the remote URL is obtained from the Staging site when navigating through administrative pages.

An alternative solution could be to request the public LayoutSet when the group has at least one public page instead of requesting the public LayoutSet when the group has no private pages.

Could you please review it?

Please, also let me know if you need further clarifications on this or you think that the Echo team should (also) review it.

Thanks in advance,
Daniel