### PR TITLE
[TS] LPS-125024 Avoid infinite loop when importing invalid LAR

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
@@ -558,6 +558,9 @@ public class DLReferencesExportImportContentProcessor
 						content = StringUtil.replace(
 							content, exportedReference, originalReference);
 					}
+					else {
+						throw portalException;
+					}
 
 					continue;
 				}


### PR DESCRIPTION
[LPS-125024](https://issues.liferay.com/browse/LPS-125024)

Using a loop condition like `while (content.contains("[$dl-reference=" + path + "$]"))` and not actually replacing anything in `content` can result in infinite loop.