### PR TITLE
[TS] LPS-124827 Additional commit to revert LPS-125882

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -1246,7 +1246,7 @@ public class JournalArticleStagedModelDataHandler
 	protected String[] getSkipImportReferenceStagedModelNames() {
 		return new String[] {
 			AssetDisplayPageEntry.class.getName(),
-			FriendlyURLEntry.class.getName(), Layout.class.getName()
+			FriendlyURLEntry.class.getName()
 		};
 	}
 


### PR DESCRIPTION
The fix of [LPS-125882](https://issues.liferay.com/browse/LPS-125882) (commit: https://github.com/liferay/liferay-portal/commit/4ca5e750e6642f05cee2501679087de5de7004ce) makes the case of [LPS-124827](https://issues.liferay.com/browse/LPS-124827) fail, but only in the versions after 7.3. The difference is that Data Engine actually updates the Link To Page fields of a JournalArticle during publication. [LPS-125882](https://issues.liferay.com/browse/LPS-125882) can only be applied if there's no actual update, so it will still work 7.3.x and all earlier versions.