### PR TITLE
[TS] LPS-127207

### DIFF
--- a/modules/apps/export-import/export-import-changeset-api/src/main/java/com/liferay/exportimport/changeset/Changeset.java
+++ b/modules/apps/export-import/export-import-changeset-api/src/main/java/com/liferay/exportimport/changeset/Changeset.java
@@ -163,9 +163,7 @@ public class Changeset implements Serializable {
 			String stagedModelClassName = stagedModel.getModelClassName();
 
 			if (stagedModelClassName.equals(parentClassName)) {
-				for (Object object :
-						hierarchyFunction.apply(parentStagedModel)) {
-
+				for (Object object : hierarchyFunction.apply(stagedModel)) {
 					StagedModel childStagedModel = (StagedModel)object;
 
 					childrenStagedModels.add(childStagedModel);

--- a/modules/apps/export-import/export-import-changeset-api/src/main/java/com/liferay/exportimport/changeset/Changeset.java
+++ b/modules/apps/export-import/export-import-changeset-api/src/main/java/com/liferay/exportimport/changeset/Changeset.java
@@ -97,12 +97,8 @@ public class Changeset implements Serializable {
 
 			StagedModel stagedModel = supplier.get();
 
-			String stagedModelClassName =
-				ExportImportClassedModelUtil.getClassName(stagedModel);
-
 			_collectChildrenStagedModels(
-				_changeset._stagedModels, stagedModel, stagedModelClassName,
-				function);
+				_changeset._stagedModels, stagedModel, function);
 
 			return this;
 		}
@@ -150,8 +146,10 @@ public class Changeset implements Serializable {
 
 	private static void _collectChildrenStagedModels(
 		List<StagedModel> childrenStagedModels, StagedModel parentStagedModel,
-		String parentClassName,
 		Function<StagedModel, Collection<?>> hierarchyFunction) {
+
+		String parentClassName = ExportImportClassedModelUtil.getClassName(
+			parentStagedModel);
 
 		Queue<StagedModel> queue = new LinkedList<>();
 

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/PublishFolderMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/PublishFolderMVCActionCommand.java
@@ -92,10 +92,7 @@ public class PublishFolderMVCActionCommand extends BaseMVCActionCommand {
 
 			for (Object childObject : childObjects) {
 				if (childObject instanceof JournalFolder) {
-					JournalFolder childJournalFolder =
-						(JournalFolder)childObject;
-
-					stagedModels.add(childJournalFolder);
+					stagedModels.add((JournalFolder)childObject);
 				}
 				else if (childObject instanceof JournalArticle) {
 					JournalArticle journalArticle = (JournalArticle)childObject;

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/PublishFolderMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/PublishFolderMVCActionCommand.java
@@ -96,9 +96,6 @@ public class PublishFolderMVCActionCommand extends BaseMVCActionCommand {
 						(JournalFolder)childObject;
 
 					stagedModels.add(childJournalFolder);
-
-					stagedModels.addAll(
-						_getFoldersAndArticles(childJournalFolder));
 				}
 				else if (childObject instanceof JournalArticle) {
 					JournalArticle journalArticle = (JournalArticle)childObject;


### PR DESCRIPTION
Hi @vendeltoreki ,

I've found that Changeset "recursion" in _collectChildrenStagedModels does not carry over the current stagedModel, instead it recalls the parentStagedModel, resulting in an endless cycle. This was instroduced in https://github.com/shuyangzhou/liferay-portal/pull/9044/commits/056fede5a6b436ff2c21a74ec7d8f474bbec3a97 where an original recursion was transformed into the queue solution.
I've also found that PublishFolderMVCActionCommand is also using recursion to track all descendants of the parent folder. I've removed this, as Changeset is already handling this case.

Can you please review?
https://issues.liferay.com/browse/LPS-127207

Thanks,
Balázs