### PR TITLE
LPS-127072 if staging is enabled and DDL is not staged, liveGroup nee…

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/display/context/DDMDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/display/context/DDMDisplayContext.java
@@ -50,6 +50,8 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.PortalPreferences;
@@ -61,6 +63,7 @@ import com.liferay.portal.kernel.template.TemplateHandler;
 import com.liferay.portal.kernel.template.TemplateHandlerRegistryUtil;
 import com.liferay.portal.kernel.template.comparator.TemplateHandlerComparator;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -1003,6 +1006,18 @@ public class DDMDisplayContext {
 
 		if (showAncestorScopes()) {
 			groupIds = PortalUtil.getCurrentAndAncestorSiteGroupIds(groupIds);
+		}
+
+		Layout layout = _ddmWebRequestHelper.getLayout();
+
+		Group group = null;
+
+		if (layout != null) {
+			group = layout.getGroup();
+		}
+
+		if ((group != null) && !group.isStagingGroup()) {
+			groupIds = ArrayUtil.append(groupIds, group.getGroupId());
 		}
 
 		List<DDMStructure> results = null;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-127072

Notes from @brianikim:
>The issue occurs here due to to the call here: [DDMDisplayContext](https://github.com/liferay/liferay-portal/blob/fa6ecdb8ad0e059654aff51e1216a57a8ddd272a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/display/context/DDMDisplayContext.java#L998). When staging is enabled, but DDL is not staged, the groupId returned only has the staging group id. The intended behavior, as established, by [PTR-2198](https://issues.liferay.com/browse/PTR-2198) is to also include the liveGroupId.
>
>The solution was implemented after an approval from the product team in the PTR.