### PR TITLE
[TS] LPS-128300 Allow for escaped quotations and escaped apostrophes to be used as stop strings

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
@@ -736,15 +736,17 @@ public class DLReferencesExportImportContentProcessor
 
 	private static final String[] _DL_REFERENCE_LEGACY_STOP_STRINGS = {
 		StringPool.APOSTROPHE, StringPool.APOSTROPHE_ENCODED,
-		StringPool.CLOSE_BRACKET, StringPool.CLOSE_CURLY_BRACE,
-		StringPool.CLOSE_PARENTHESIS, StringPool.GREATER_THAN,
-		StringPool.LESS_THAN, StringPool.PIPE, StringPool.QUOTE,
-		StringPool.QUOTE_ENCODED, StringPool.SPACE
+		StringPool.BACK_SLASH + StringPool.APOSTROPHE,
+		StringPool.BACK_SLASH + StringPool.QUOTE, StringPool.CLOSE_BRACKET,
+		StringPool.CLOSE_CURLY_BRACE, StringPool.CLOSE_PARENTHESIS,
+		StringPool.GREATER_THAN, StringPool.LESS_THAN, StringPool.PIPE,
+		StringPool.QUOTE, StringPool.QUOTE_ENCODED, StringPool.SPACE
 	};
 
 	private static final String[] _DL_REFERENCE_STOP_STRINGS = {
 		StringPool.APOSTROPHE, StringPool.APOSTROPHE_ENCODED,
-		StringPool.BACK_SLASH, StringPool.CLOSE_BRACKET,
+		StringPool.BACK_SLASH + StringPool.APOSTROPHE,
+		StringPool.BACK_SLASH + StringPool.QUOTE, StringPool.CLOSE_BRACKET,
 		StringPool.CLOSE_CURLY_BRACE, StringPool.CLOSE_PARENTHESIS,
 		StringPool.GREATER_THAN, StringPool.LESS_THAN, StringPool.NEW_LINE,
 		StringPool.PIPE, StringPool.QUESTION, StringPool.QUOTE,


### PR DESCRIPTION
Forwarding from https://github.com/vendeltoreki/liferay-portal/pull/175 , since it conflicted with the PR https://github.com/vendeltoreki/liferay-portal/pull/179 of [LPS-128305](https://issues.liferay.com/browse/LPS-128305).
I rebased the changes, since this commit will fix other scenarios as well.
cc: @ChrisKian