### PR TITLE
[TS] LPS-128693

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/content/processor/FragmentEntryLinkExportImportContentProcessor.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/content/processor/FragmentEntryLinkExportImportContentProcessor.java
@@ -247,6 +247,22 @@ public class FragmentEntryLinkExportImportContentProcessor
 		}
 	}
 
+	private void _replaceClassPK(
+		JSONObject configurationValueJSONObject,
+		PortletDataContext portletDataContext) {
+
+		String className = configurationValueJSONObject.getString("className");
+
+		Map<Long, Long> primaryKeys =
+			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(className);
+
+		long classPK = configurationValueJSONObject.getLong("classPK");
+
+		classPK = MapUtil.getLong(primaryKeys, classPK, classPK);
+
+		configurationValueJSONObject.put("classPK", classPK);
+	}
+
 	private void _replaceConfigurationExportContentReferences(
 			JSONObject editableValuesJSONObject,
 			boolean exportReferencedContent,
@@ -302,11 +318,16 @@ public class FragmentEntryLinkExportImportContentProcessor
 			JSONObject configurationValueJSONObject =
 				editableProcessorJSONObject.getJSONObject(editableKey);
 
-			if ((configurationValueJSONObject != null) &&
-				configurationValueJSONObject.has("siteNavigationMenuId")) {
+			if (configurationValueJSONObject != null) {
+				if (configurationValueJSONObject.has("siteNavigationMenuId")) {
+					_replaceSiteNavigationMenuIds(
+						configurationValueJSONObject, portletDataContext);
+				}
 
-				_replaceSiteNavigationMenuIds(
-					configurationValueJSONObject, portletDataContext);
+				if (configurationValueJSONObject.has("classPK")) {
+					_replaceClassPK(
+						configurationValueJSONObject, portletDataContext);
+				}
 			}
 		}
 	}

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/LayoutClassedModelUsageStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/LayoutClassedModelUsageStagedModelDataHandler.java
@@ -24,6 +24,7 @@ import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.staged.model.repository.StagedModelRepository;
+import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.layout.model.LayoutClassedModelUsage;
 import com.liferay.layout.service.LayoutClassedModelUsageLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -198,6 +199,22 @@ public class LayoutClassedModelUsageStagedModelDataHandler
 			layoutClassedModelUsage.getClassPK());
 
 		importedLayoutClassedModelUsage.setClassPK(classPK);
+
+		Map<Long, Long> fragmentLinkEntryIds =
+			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
+				FragmentEntryLink.class.getName());
+
+		Long containerKey = Long.valueOf(
+			layoutClassedModelUsage.getContainerKey());
+
+		containerKey = MapUtil.getLong(
+			fragmentLinkEntryIds, containerKey, containerKey);
+
+		importedLayoutClassedModelUsage.setContainerKey(
+			containerKey.toString());
+
+		importedLayoutClassedModelUsage.setContainerType(
+			_portal.getClassNameId(FragmentEntryLink.class));
 
 		Element element = portletDataContext.getImportDataStagedModelElement(
 			layoutClassedModelUsage);


### PR DESCRIPTION
From @jesseyeh-liferay 

> [LPS-128693](https://issues.liferay.com/browse/LPS-128693) resolves an issue in which Web Content referenced by a Content Display fragment does not display correctly after being exported and imported into a new portal instance. This issue occurs because the `editableValues` column value in the `FragmentEntryLink` table contains the `classPK` value from the old instance. This solution updates this to the correct value, and also updates the `containerKey` and `containerType` column values in the `LayoutClassedModelUsage` table to fix a NullReferenceException when navigating to Web Content > View Usages post-import.