### PR TITLE
LPS-128693 Update usages with the correct containerKey and containerType values

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/LayoutClassedModelUsageStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/LayoutClassedModelUsageStagedModelDataHandler.java
@@ -24,6 +24,7 @@ import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.staged.model.repository.StagedModelRepository;
+import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.layout.model.LayoutClassedModelUsage;
 import com.liferay.layout.service.LayoutClassedModelUsageLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -198,6 +199,22 @@ public class LayoutClassedModelUsageStagedModelDataHandler
 			layoutClassedModelUsage.getClassPK());
 
 		importedLayoutClassedModelUsage.setClassPK(classPK);
+
+		Map<Long, Long> fragmentLinkEntryIds =
+			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
+				FragmentEntryLink.class.getName());
+
+		Long containerKey = Long.valueOf(
+			layoutClassedModelUsage.getContainerKey());
+
+		containerKey = MapUtil.getLong(
+			fragmentLinkEntryIds, containerKey, containerKey);
+
+		importedLayoutClassedModelUsage.setContainerKey(
+			containerKey.toString());
+
+		importedLayoutClassedModelUsage.setContainerType(
+			_portal.getClassNameId(FragmentEntryLink.class));
 
 		Element element = portletDataContext.getImportDataStagedModelElement(
 			layoutClassedModelUsage);


### PR DESCRIPTION
Forwarding one commit from https://github.com/vendeltoreki/liferay-portal/pull/185 : https://github.com/vendeltoreki/liferay-portal/pull/187/commits/8c08914bfc7c71996e9f0714f9fb00e3b1ac0e80 . The first part of [LPS-128693](https://issues.liferay.com/browse/LPS-128693) case was already resolved in [LPS-127548](https://issues.liferay.com/browse/LPS-127548) by https://github.com/liferay/liferay-portal/commit/f062e0ab20fc7c160564af032220577b85e0ec22 and https://github.com/liferay/liferay-portal/commit/bda2aacda4f87b4ed8569160f6326334a490bdb8 . This commit will make sure that usages of the web contents are handled correctly as well.