### PR TITLE
LPS-131527 | master

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetBranchLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetBranchLocalServiceImpl.java
@@ -363,8 +363,19 @@ public class LayoutSetBranchLocalServiceImpl
 		List<LayoutSetBranch> layoutSetBranches =
 			layoutSetBranchPersistence.findByG_P(groupId, privateLayout);
 
+		LayoutSetBranch masterLayaoutSetBranch = null;
+
 		for (LayoutSetBranch layoutSetBranch : layoutSetBranches) {
-			deleteLayoutSetBranch(layoutSetBranch, includeMaster);
+			if (layoutSetBranch.isMaster()) {
+				masterLayaoutSetBranch = layoutSetBranch;
+			}
+			else {
+				deleteLayoutSetBranch(layoutSetBranch, includeMaster);
+			}
+		}
+
+		if (masterLayaoutSetBranch != null) {
+			deleteLayoutSetBranch(masterLayaoutSetBranch, includeMaster);
 		}
 	}
 


### PR DESCRIPTION
Hello @vendeltoreki,

This [LPS-131527](https://issues.liferay.com/browse/LPS-131527) solves a problem produced indirectly by the [LPS-119920](https://issues.liferay.com/browse/LPS-119920). The [LPS-119920](https://issues.liferay.com/browse/LPS-119920) added controls to avoid the existence of orphan layouts when a page variation set is deleted. Part of those controls is based on the presence of the master variation. If the master variation is deleted first, those controls don't work correctly, and all layouts will be deleted wrongly. The modification made in this PR ensures that the master variation is deleted in the last place, avoiding the problem.

Please, let me know if you have any doubt.