### PR TITLE
LPS-132518 Fixing setParameter: Using searchParams.set

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/js/main.js
@@ -1128,7 +1128,7 @@ AUI.add(
 											controlCheckbox.disabled &&
 											controlCheckbox.checked
 										) {
-											portletURL.setParameter(
+											portletURL.searchParams.set(
 												controlCheckbox.name.replace(
 													instance.NS,
 													''


### PR DESCRIPTION
Hi @vendeltoreki 

Could you please review my fix?

Calling the setParameter function on the JS URL object cause an: Uncaught TypeError: portletURL.setParameter is not a function
The setParameter is not an existing function for the URL object.
Instead of we can use portletURL**.searchParams.set**

https://issues.liferay.com/browse/LPS-132518

Thanks, Roland