### PR TITLE
[TS] LPS-130397 Attempt to get the file entry based on the file name as well as title

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
@@ -256,8 +256,23 @@ public class DLReferencesExportImportContentProcessor
 					String title = MapUtil.getString(map, "title");
 
 					if (Validator.isNotNull(title)) {
-						fileEntry = _dlAppLocalService.getFileEntry(
-							groupId, folderId, title);
+						try {
+							fileEntry =
+								_dlAppLocalService.getFileEntryByFileName(
+									groupId, folderId, title);
+						}
+						catch (NoSuchFileEntryException
+									noSuchFileEntryException) {
+
+							if (_log.isDebugEnabled()) {
+								_log.debug(
+									noSuchFileEntryException,
+									noSuchFileEntryException);
+							}
+
+							fileEntry = _dlAppLocalService.getFileEntry(
+								groupId, folderId, title);
+						}
 					}
 					else {
 						DLFileEntry dlFileEntry =


### PR DESCRIPTION
If a file named "test.png" is added to the Document Library then the file can be accessed by either of the following URLs:

http://localhost:8080/documents/41371/0/test.png
http://localhost:8080/documents/41371/0/test

This is due to the file entry having a _fileName_ as well as a _title_. In https://issues.liferay.com/browse/LPS-123544 the logic was updated to account for both possibilities - https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java#L457-L469

The changes in this pull are the same allowing for getting the file based on either field.

The difference in testing on https://issues.liferay.com/browse/LPS-130397 could be attributed different URLs being used thus causing the discrepancy with QA's testing.

Please let me know if there are any questions or issues. Thank you.