### PR TITLE
[TS] LPS-133752 Revert changes of LPS-133316

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/lifecycle/JournalCacheExportImportLifecycleListener.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/lifecycle/JournalCacheExportImportLifecycleListener.java
@@ -124,8 +124,6 @@ public class JournalCacheExportImportLifecycleListener
 	public void onPortletExportFailed(
 			PortletDataContext portletDataContext, Throwable throwable)
 		throws Exception {
-
-		_journalArticleExportImportCache.clear();
 	}
 
 	@Override
@@ -136,8 +134,6 @@ public class JournalCacheExportImportLifecycleListener
 	@Override
 	public void onPortletExportSucceeded(PortletDataContext portletDataContext)
 		throws Exception {
-
-		_journalArticleExportImportCache.clear();
 	}
 
 	@Override


### PR DESCRIPTION
**Notes:**
* Reverting [LPS-133316](https://issues.liferay.com/browse/LPS-133316). It seems like the [JournalCacheExportImportLifecycleListener.onPortletExportSucceeded(..)](https://github.com/liferay/liferay-portal/blob/002d30de841100a6dc52f338d31f2bab6489c7f3/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/lifecycle/JournalCacheExportImportLifecycleListener.java#L137) method is called multiple times during a single export process from [StagedGroupStagedModelDataHandler.exportPortlet(..)](https://github.com/liferay/liferay-portal/blob/c3275939d8e02e99a99a9fa3d30f7297f2662730/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/exportimport/data/handler/StagedGroupStagedModelDataHandler.java#L393). Technically, this shouldn't fail the [LPS-133752](https://issues.liferay.com/browse/LPS-133752) scenario, so that still has to be investigated.
