### PR TITLE
LPS-133316 Don't use cache from previous export

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalArticleExportImportContentProcessor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalArticleExportImportContentProcessor.java
@@ -111,7 +111,11 @@ public class JournalArticleExportImportContentProcessor
 		String processedContent = _journalArticleExportImportCache.get(
 			sb.toString());
 
-		if (Validator.isNotNull(processedContent)) {
+		String path = ExportImportPathUtil.getModelPath(stagedModel);
+
+		if (Validator.isNotNull(processedContent) &&
+			portletDataContext.hasPrimaryKey(String.class, path)) {
+
 			Element entityElement = portletDataContext.getExportDataElement(
 				stagedModel);
 


### PR DESCRIPTION
Hi @vendeltoreki ,

Previous solution of dropping the cache after portlet export invalidated the use of the cache. While https://issues.liferay.com/browse/LPS-131585 is being investigated, this should be a fair way to reset the cache when needed.

Can you please review?
https://issues.liferay.com/browse/LPS-133316

Thanks,
Balázs

p.s.
related to https://issues.liferay.com/browse/LPS-131585