### PR TITLE
[TS] LPS-132134

### DIFF
--- a/portal-impl/src/com/liferay/portal/service.xml
+++ b/portal-impl/src/com/liferay/portal/service.xml
@@ -1276,6 +1276,7 @@
 		<!-- References -->
 
 		<reference entity="Group" package-path="com.liferay.portal" />
+		<reference entity="Layout" package-path="com.liferay.portal" />
 		<reference entity="LayoutSet" package-path="com.liferay.portal" />
 		<reference entity="Resource" package-path="com.liferay.portal" />
 		<reference entity="User" package-path="com.liferay.portal" />

--- a/portal-impl/src/com/liferay/portal/service/base/LayoutSetPrototypeLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LayoutSetPrototypeLocalServiceBaseImpl.java
@@ -46,6 +46,8 @@ import com.liferay.portal.kernel.service.PersistedModelLocalServiceRegistry;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
 import com.liferay.portal.kernel.service.persistence.GroupFinder;
 import com.liferay.portal.kernel.service.persistence.GroupPersistence;
+import com.liferay.portal.kernel.service.persistence.LayoutFinder;
+import com.liferay.portal.kernel.service.persistence.LayoutPersistence;
 import com.liferay.portal.kernel.service.persistence.LayoutSetPersistence;
 import com.liferay.portal.kernel.service.persistence.LayoutSetPrototypePersistence;
 import com.liferay.portal.kernel.service.persistence.UserFinder;
@@ -628,6 +630,65 @@ public abstract class LayoutSetPrototypeLocalServiceBaseImpl
 	}
 
 	/**
+	 * Returns the layout local service.
+	 *
+	 * @return the layout local service
+	 */
+	public com.liferay.portal.kernel.service.LayoutLocalService
+		getLayoutLocalService() {
+
+		return layoutLocalService;
+	}
+
+	/**
+	 * Sets the layout local service.
+	 *
+	 * @param layoutLocalService the layout local service
+	 */
+	public void setLayoutLocalService(
+		com.liferay.portal.kernel.service.LayoutLocalService
+			layoutLocalService) {
+
+		this.layoutLocalService = layoutLocalService;
+	}
+
+	/**
+	 * Returns the layout persistence.
+	 *
+	 * @return the layout persistence
+	 */
+	public LayoutPersistence getLayoutPersistence() {
+		return layoutPersistence;
+	}
+
+	/**
+	 * Sets the layout persistence.
+	 *
+	 * @param layoutPersistence the layout persistence
+	 */
+	public void setLayoutPersistence(LayoutPersistence layoutPersistence) {
+		this.layoutPersistence = layoutPersistence;
+	}
+
+	/**
+	 * Returns the layout finder.
+	 *
+	 * @return the layout finder
+	 */
+	public LayoutFinder getLayoutFinder() {
+		return layoutFinder;
+	}
+
+	/**
+	 * Sets the layout finder.
+	 *
+	 * @param layoutFinder the layout finder
+	 */
+	public void setLayoutFinder(LayoutFinder layoutFinder) {
+		this.layoutFinder = layoutFinder;
+	}
+
+	/**
 	 * Returns the layout set local service.
 	 *
 	 * @return the layout set local service
@@ -849,6 +910,18 @@ public abstract class LayoutSetPrototypeLocalServiceBaseImpl
 
 	@BeanReference(type = GroupFinder.class)
 	protected GroupFinder groupFinder;
+
+	@BeanReference(
+		type = com.liferay.portal.kernel.service.LayoutLocalService.class
+	)
+	protected com.liferay.portal.kernel.service.LayoutLocalService
+		layoutLocalService;
+
+	@BeanReference(type = LayoutPersistence.class)
+	protected LayoutPersistence layoutPersistence;
+
+	@BeanReference(type = LayoutFinder.class)
+	protected LayoutFinder layoutFinder;
 
 	@BeanReference(
 		type = com.liferay.portal.kernel.service.LayoutSetLocalService.class

--- a/portal-impl/src/com/liferay/portal/service/base/LayoutSetPrototypeServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LayoutSetPrototypeServiceBaseImpl.java
@@ -27,6 +27,8 @@ import com.liferay.portal.kernel.service.LayoutSetPrototypeService;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeServiceUtil;
 import com.liferay.portal.kernel.service.persistence.GroupFinder;
 import com.liferay.portal.kernel.service.persistence.GroupPersistence;
+import com.liferay.portal.kernel.service.persistence.LayoutFinder;
+import com.liferay.portal.kernel.service.persistence.LayoutPersistence;
 import com.liferay.portal.kernel.service.persistence.LayoutSetPersistence;
 import com.liferay.portal.kernel.service.persistence.LayoutSetPrototypePersistence;
 import com.liferay.portal.kernel.service.persistence.UserFinder;
@@ -220,6 +222,85 @@ public abstract class LayoutSetPrototypeServiceBaseImpl
 	 */
 	public void setGroupFinder(GroupFinder groupFinder) {
 		this.groupFinder = groupFinder;
+	}
+
+	/**
+	 * Returns the layout local service.
+	 *
+	 * @return the layout local service
+	 */
+	public com.liferay.portal.kernel.service.LayoutLocalService
+		getLayoutLocalService() {
+
+		return layoutLocalService;
+	}
+
+	/**
+	 * Sets the layout local service.
+	 *
+	 * @param layoutLocalService the layout local service
+	 */
+	public void setLayoutLocalService(
+		com.liferay.portal.kernel.service.LayoutLocalService
+			layoutLocalService) {
+
+		this.layoutLocalService = layoutLocalService;
+	}
+
+	/**
+	 * Returns the layout remote service.
+	 *
+	 * @return the layout remote service
+	 */
+	public com.liferay.portal.kernel.service.LayoutService getLayoutService() {
+		return layoutService;
+	}
+
+	/**
+	 * Sets the layout remote service.
+	 *
+	 * @param layoutService the layout remote service
+	 */
+	public void setLayoutService(
+		com.liferay.portal.kernel.service.LayoutService layoutService) {
+
+		this.layoutService = layoutService;
+	}
+
+	/**
+	 * Returns the layout persistence.
+	 *
+	 * @return the layout persistence
+	 */
+	public LayoutPersistence getLayoutPersistence() {
+		return layoutPersistence;
+	}
+
+	/**
+	 * Sets the layout persistence.
+	 *
+	 * @param layoutPersistence the layout persistence
+	 */
+	public void setLayoutPersistence(LayoutPersistence layoutPersistence) {
+		this.layoutPersistence = layoutPersistence;
+	}
+
+	/**
+	 * Returns the layout finder.
+	 *
+	 * @return the layout finder
+	 */
+	public LayoutFinder getLayoutFinder() {
+		return layoutFinder;
+	}
+
+	/**
+	 * Sets the layout finder.
+	 *
+	 * @param layoutFinder the layout finder
+	 */
+	public void setLayoutFinder(LayoutFinder layoutFinder) {
+		this.layoutFinder = layoutFinder;
 	}
 
 	/**
@@ -487,6 +568,21 @@ public abstract class LayoutSetPrototypeServiceBaseImpl
 
 	@BeanReference(type = GroupFinder.class)
 	protected GroupFinder groupFinder;
+
+	@BeanReference(
+		type = com.liferay.portal.kernel.service.LayoutLocalService.class
+	)
+	protected com.liferay.portal.kernel.service.LayoutLocalService
+		layoutLocalService;
+
+	@BeanReference(type = com.liferay.portal.kernel.service.LayoutService.class)
+	protected com.liferay.portal.kernel.service.LayoutService layoutService;
+
+	@BeanReference(type = LayoutPersistence.class)
+	protected LayoutPersistence layoutPersistence;
+
+	@BeanReference(type = LayoutFinder.class)
+	protected LayoutFinder layoutFinder;
 
 	@BeanReference(
 		type = com.liferay.portal.kernel.service.LayoutSetLocalService.class

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetPrototypeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetPrototypeLocalServiceImpl.java
@@ -24,7 +24,6 @@ import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.persistence.LayoutUtil;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
@@ -257,7 +256,7 @@ public class LayoutSetPrototypeLocalServiceImpl
 			Group group = groupLocalService.getLayoutSetPrototypeGroup(
 				layoutSetPrototype.getCompanyId(), layoutSetPrototypeId);
 
-			List<Layout> layouts = LayoutLocalServiceUtil.getLayouts(
+			List<Layout> layouts = layoutLocalService.getLayouts(
 				group.getGroupId(), true);
 
 			for (Layout layout : layouts) {

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetPrototypeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetPrototypeLocalServiceImpl.java
@@ -18,13 +18,17 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.RequiredLayoutSetPrototypeException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.persistence.LayoutUtil;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.service.base.LayoutSetPrototypeLocalServiceBaseImpl;
@@ -245,6 +249,52 @@ public class LayoutSetPrototypeLocalServiceImpl
 
 		UnicodeProperties settingsUnicodeProperties =
 			layoutSetPrototype.getSettingsProperties();
+
+		boolean oldLayoutsUpdateable = GetterUtil.getBoolean(
+			settingsUnicodeProperties.getProperty("layoutsUpdateable"));
+
+		if (oldLayoutsUpdateable != layoutsUpdateable) {
+			Group group = groupLocalService.getLayoutSetPrototypeGroup(
+				layoutSetPrototype.getCompanyId(), layoutSetPrototypeId);
+
+			List<Layout> layouts = LayoutLocalServiceUtil.getLayouts(
+				group.getGroupId(), true);
+
+			for (Layout layout : layouts) {
+				UnicodeProperties typeSettingsUnicodeProperties =
+					layout.getTypeSettingsProperties();
+
+				if (typeSettingsUnicodeProperties.containsKey(
+						"layoutUpdateable")) {
+
+					typeSettingsUnicodeProperties.setProperty(
+						"layoutUpdateable", String.valueOf(layoutsUpdateable));
+
+					layout.setTypeSettingsProperties(
+						typeSettingsUnicodeProperties);
+
+					List<Layout> childLayouts =
+						LayoutUtil.findBySourcePrototypeLayoutUuid(
+							layout.getUuid());
+
+					for (Layout childLayout : childLayouts) {
+						UnicodeProperties childTypeSettingsUnicodeProperties =
+							childLayout.getTypeSettingsProperties();
+
+						if (childTypeSettingsUnicodeProperties.containsKey(
+								"layoutUpdateable")) {
+
+							childTypeSettingsUnicodeProperties.setProperty(
+								"layoutUpdateable",
+								String.valueOf(layoutsUpdateable));
+
+							childLayout.setTypeSettingsProperties(
+								childTypeSettingsUnicodeProperties);
+						}
+					}
+				}
+			}
+		}
 
 		settingsUnicodeProperties.put(
 			"layoutsUpdateable", String.valueOf(layoutsUpdateable));


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-132134
https://issues.liferay.com/browse/LPP-40819

Hi @vendeltoreki!

This is a fix related to site templates and the layoutUpdateable setting. When a site is created based off of a site template, the setting for whether layouts are allowed to be edited or not is passed down to the individual layouts of that site. However, when the setting is changed on the site template, the setting remains on widget page layouts and therefore a layout on a site can remain unable to be edited based off of the previous setting of the site template. This fix checks if a change was made to the setting, checks each layout on the site template to see if the setting is attached to that layout and then alters it on both the source layout as well as all layouts that have it as a source layout. Please let me know if you have any questions or concerns. Thanks!