### PR TITLE
[TS] LPS-137035

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/exportimport/staged/model/repository/DDMFormInstanceStagedModelRepository.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/exportimport/staged/model/repository/DDMFormInstanceStagedModelRepository.java
@@ -23,6 +23,7 @@ import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.kernel.lar.StagedModelModifiedDateComparator;
 import com.liferay.exportimport.staged.model.repository.StagedModelRepository;
+import com.liferay.exportimport.staged.model.repository.StagedModelRepositoryHelper;
 import com.liferay.portal.kernel.dao.orm.ExportActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -110,6 +111,12 @@ public class DDMFormInstanceStagedModelRepository
 		}
 
 		deleteDDMStructures(formInstanceDDMStructureIds);
+	}
+
+	@Override
+	public DDMFormInstance fetchMissingReference(String uuid, long groupId) {
+		return _stagedModelRepositoryHelper.fetchMissingReference(
+			uuid, groupId, this);
 	}
 
 	@Override
@@ -201,5 +208,8 @@ public class DDMFormInstanceStagedModelRepository
 
 	@Reference
 	private DDMStructureLocalService _ddmStructureLocalService;
+
+	@Reference
+	private StagedModelRepositoryHelper _stagedModelRepositoryHelper;
 
 }


### PR DESCRIPTION
[LPS-137035](https://issues.liferay.com/browse/LPS-137035)

From @jesseyeh-liferay: 

> **Issue**
> When importing a site containing a portlet reference to a form, a missing reference error to the form appears even if the form had already been imported beforehand.
> 
> **Solution**
> This error occurs because in [`BaseStagedModelDataHandler`'s `fetchMissingReference` method](https://github.com/jesseyeh-liferay/liferay-portal/blob/85ec5558383ead431ef152d67df3af5c556ac69a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/data/handler/base/BaseStagedModelDataHandler.java#L127-L137), `DDMFormInstanceStagedModelDataHandler` overrides the implementation for `getStagedModelRepository()`, which returns a non-null `StagedModelRepository` object. This object then calls `fetchMissingReference`, but because `DDMFormInstanceStagedModelRepository` provides no overridden implementation for this method, [the default implementation in `StagedModelRepository` is used instead, which always returns null](https://github.com/jesseyeh-liferay/liferay-portal/blob/85ec5558383ead431ef152d67df3af5c556ac69a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/staged/model/repository/StagedModelRepository.java#L124-L126). To fix this, we provide an overridden implementation which uses a helper to correctly retrieve the form.