### PR TITLE
LPS-141261

### DIFF
--- a/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java
@@ -40,7 +40,6 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
@@ -61,7 +60,6 @@ import java.io.IOException;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Optional;
 
 import javax.portlet.PortletURL;
@@ -322,28 +320,16 @@ public class LayoutSiteNavigationMenuItemType
 			return false;
 		}
 
-		Map<Long, Long> layoutPlids =
-			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
-				Layout.class);
-
-		long plid = MapUtil.getLong(
-			layoutPlids, layout.getPlid(), layout.getPlid());
-
-		Layout importedLayout = _layoutLocalService.fetchLayout(plid);
-
-		if (importedLayout != null) {
-			importedSiteNavigationMenuItem.setTypeSettings(
-				UnicodePropertiesBuilder.fastLoad(
-					siteNavigationMenuItem.getTypeSettings()
-				).put(
-					"layoutUuid", importedLayout.getUuid()
-				).put(
-					"groupId", String.valueOf(importedLayout.getGroupId())
-				).put(
-					"privateLayout",
-					String.valueOf(importedLayout.isPrivateLayout())
-				).buildString());
-		}
+		importedSiteNavigationMenuItem.setTypeSettings(
+			UnicodePropertiesBuilder.fastLoad(
+				siteNavigationMenuItem.getTypeSettings()
+			).put(
+				"layoutUuid", layout.getUuid()
+			).put(
+				"groupId", String.valueOf(layout.getGroupId())
+			).put(
+				"privateLayout", String.valueOf(layout.isPrivateLayout())
+			).buildString());
 
 		return true;
 	}


### PR DESCRIPTION
When we call `_getLayout`, we pass in the `importedSiteNavigationMenuItem` ([Reference](https://github.com/mbowerman/liferay-portal/blob/1ff14ea631aaabb72bc027113fae994ca28de2ed/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java#L303-L304))

The `importedSiteNavigationMenuItem` is guaranteed to have the `groupId` of the import group. ([Reference](https://github.com/liferay/liferay-portal/blob/1ff14ea631aaabb72bc027113fae994ca28de2ed/modules/apps/site-navigation/site-navigation-service/src/main/java/com/liferay/site/navigation/internal/exportimport/data/handler/SiteNavigationMenuItemStagedModelDataHandler.java#L160-L161))

Within the `_getLayout` method, there are three different attempts to fetch the Layout: [Attempt 1](https://github.com/mbowerman/liferay-portal/blob/1ff14ea631aaabb72bc027113fae994ca28de2ed/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java#L493-L494), [Attempt 2](https://github.com/mbowerman/liferay-portal/blob/1ff14ea631aaabb72bc027113fae994ca28de2ed/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java#L497-L499), and [Attempt 3](https://github.com/mbowerman/liferay-portal/blob/1ff14ea631aaabb72bc027113fae994ca28de2ed/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java#L509-L517).

All three of these attempts pass in `siteNavigationMenuItem.getGroupId()` to the lookup method. Since this is the `importedSiteNavigationMenuItem`, this means that we're always passing in the Group ID of the import group into the lookup method. So, the `Layout` that is returned by the `_getLayout` method is guaranteed to belong to the import group.

Therefore, it is not necessary to use the newPrimaryKeysMap here. Doing so only risks causing the wrong Layout to be fetched in the event of a plid collision. The newPrimaryKeysMap is only meant to be used for situations where we're directly referencing the old primary key, which isn't the case here.