### PR TITLE
[TS] LPS-142320

### DIFF
--- a/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/error_remote_export_exception.jspf
+++ b/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/error_remote_export_exception.jspf
@@ -56,6 +56,17 @@
 
 	<c:if test="<%= ree.getType() == RemoteExportException.NO_GROUP %>">
 		<liferay-ui:message arguments='<%= "<em>" + ree.getGroupId() + "</em>" %>' key="no-site-exists-on-the-remote-server-with-site-id-x" translateArguments="<%= false %>" />
+
+		<c:if test="<%= liveGroup.isStaged() && liveGroup.isStagedRemotely() %>">
+			<c:choose>
+				<c:when test="<%= layout.isTypeControlPanel() %>">
+					<liferay-ui:message arguments='<%= "javascript:" + liferayPortletResponse.getNamespace() + "saveGroup(true);" %>' key="you-can-also-forcibly-disable-remote-staging" />
+				</c:when>
+				<c:otherwise>
+					<liferay-ui:message key="if-everything-is-configured-correctly,-but-you-still-encounter-this-error,-the-administrator-has-the-option-to-forcibly-disable-remote-staging" />
+				</c:otherwise>
+			</c:choose>
+		</c:if>
 	</c:if>
 
 	<c:if test="<%= ree.getType() == RemoteExportException.NO_PERMISSIONS %>">

--- a/portal-impl/src/com/liferay/portlet/exportimport/service/impl/StagingLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/exportimport/service/impl/StagingLocalServiceImpl.java
@@ -792,13 +792,6 @@ public class StagingLocalServiceImpl extends StagingLocalServiceBaseImpl {
 		try {
 			GroupServiceHttp.disableStaging(httpPrincipal, remoteGroupId);
 		}
-		catch (NoSuchGroupException noSuchGroupException) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(
-					"Remote live group was already deleted",
-					noSuchGroupException);
-			}
-		}
 		catch (PrincipalException principalException) {
 
 			// LPS-52675
@@ -840,6 +833,24 @@ public class StagingLocalServiceImpl extends StagingLocalServiceBaseImpl {
 						RemoteExportException.BAD_CONNECTION);
 
 				remoteExportException.setURL(remoteURL);
+
+				throw remoteExportException;
+			}
+
+			if (_log.isWarnEnabled()) {
+				_log.warn("Forcibly disable remote staging");
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			if (!forceDisable) {
+				RemoteExportException remoteExportException =
+					new RemoteExportException(RemoteExportException.NO_GROUP);
+
+				remoteExportException.setGroupId(remoteGroupId);
 
 				throw remoteExportException;
 			}


### PR DESCRIPTION
Hi @vendeltoreki,

please review this PR related to LPS-142320!
This solution is meant to handle `NoSuchGroupException` after the exception information was removed from remote call responses due to a security related change.
I created a separate catch block for this purpose since a different message is needed to be displayed for this case and the "remote live unavailable" case.

Let me know your thoughts!

Thanks!